### PR TITLE
🐛 Phase 1 — Fix Stage 1 bugs (slots, persistence, type mismatch)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,9 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { services, staff, businessSettings } from '@/data/mock'
+import { loadStaff } from '@/lib/staffStore'
+import { loadSettings } from '@/lib/settingsStore'
 import { loadBookings, type Booking } from '@/lib/bookingsStore'
+import type { StaffMember } from '@/data/mock'
 import { format, addDays, parseISO, startOfWeek } from 'date-fns'
 import Link from 'next/link'
 
@@ -20,16 +22,19 @@ const STATUS_COLOR: Record<string, string> = {
   confirmed: 'bg-indigo-500',
   cancelled: 'bg-red-400',
   completed: 'bg-gray-400',
+  pending: 'bg-amber-400',
 }
 const STATUS_LIGHT: Record<string, string> = {
   confirmed: 'bg-indigo-50 border-indigo-200',
   cancelled: 'bg-red-50 border-red-200',
   completed: 'bg-gray-50 border-gray-200',
+  pending: 'bg-amber-50 border-amber-200',
 }
 const STATUS_TEXT: Record<string, string> = {
   confirmed: 'text-indigo-700',
   cancelled: 'text-red-600',
   completed: 'text-gray-500',
+  pending: 'text-amber-700',
 }
 
 export default function AdminOverview() {
@@ -37,11 +42,17 @@ export default function AdminOverview() {
   const [currentDate, setCurrentDate] = useState(TODAY)
   const [selectedBooking, setSelectedBooking] = useState<Booking | null>(null)
   const [bookings, setBookings] = useState<Booking[]>([])
+  const [staff, setStaff] = useState<StaffMember[]>([])
+  const [settings, setSettings] = useState(loadSettings())
 
-  useEffect(() => { setBookings(loadBookings()) }, [])
+  useEffect(() => {
+    setBookings(loadBookings())
+    setStaff(loadStaff())
+    setSettings(loadSettings())
+  }, [])
 
-  const openHour = parseInt(businessSettings.openTime.split(':')[0])
-  const closeHour = parseInt(businessSettings.closeTime.split(':')[0])
+  const openHour = parseInt(settings.openTime.split(':')[0])
+  const closeHour = parseInt(settings.closeTime.split(':')[0])
   const hours = Array.from({ length: closeHour - openHour }, (_, i) => openHour + i)
   const activeStaff = staff.filter(m => m.active)
 
@@ -54,13 +65,14 @@ export default function AdminOverview() {
     bookings.filter(b => b.date === date && b.status !== 'cancelled')
 
   const todayAll = bookings.filter(b => b.date === TODAY && b.status !== 'cancelled')
+  const pendingCount = bookings.filter(b => b.status === 'pending').length
   const totalRevenue = bookings
     .filter(b => b.status === 'confirmed' || b.status === 'completed')
     .reduce((sum, b) => sum + b.servicePrice, 0)
 
   const stats = [
     { label: "Today's appointments", value: todayAll.length, color: 'text-indigo-600 bg-indigo-50' },
-    { label: 'Pending confirmation', value: 0, color: 'text-amber-600 bg-amber-50' },
+    { label: 'Pending confirmation', value: pendingCount, color: 'text-amber-600 bg-amber-50' },
     { label: 'Total revenue', value: `€${totalRevenue}`, color: 'text-green-600 bg-green-50' },
     { label: 'Active staff', value: activeStaff.length, color: 'text-purple-600 bg-purple-50' },
   ]
@@ -235,28 +247,29 @@ export default function AdminOverview() {
 
       {/* Detail popover */}
       {selectedBooking && (() => {
-        const b = selectedBooking
-        const member = staff.find(m => m.id === b.staffId)
+        const bk = selectedBooking
+        const member = staff.find(m => m.id === bk.staffId)
         return (
           <div className="fixed bottom-6 right-6 z-50 bg-white rounded-2xl shadow-2xl border border-gray-100 w-72 p-5">
             <div className="flex items-center justify-between mb-3">
               <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${
-                b.status === 'confirmed' ? 'bg-green-100 text-green-700'
-                : b.status === 'completed' ? 'bg-gray-100 text-gray-500'
+                bk.status === 'confirmed' ? 'bg-green-100 text-green-700'
+                : bk.status === 'completed' ? 'bg-gray-100 text-gray-500'
+                : bk.status === 'pending' ? 'bg-amber-100 text-amber-700'
                 : 'bg-red-100 text-red-600'
-              }`}>{b.status}</span>
+              }`}>{bk.status}</span>
               <button onClick={() => setSelectedBooking(null)} className="text-gray-300 hover:text-gray-600 text-lg leading-none">×</button>
             </div>
-            <p className="font-bold text-gray-900">{b.customerName}</p>
-            <p className="text-xs text-gray-400 font-mono mb-1">{b.ref}</p>
-            <p className="text-sm text-indigo-600 font-medium">{b.serviceName}</p>
+            <p className="font-bold text-gray-900">{bk.customerName}</p>
+            <p className="text-xs text-gray-400 font-mono mb-1">{bk.ref}</p>
+            <p className="text-sm text-indigo-600 font-medium">{bk.serviceName}</p>
             <div className="mt-3 space-y-1.5 text-sm text-gray-500">
-              <p>📅 {format(parseISO(b.date), 'EEE d MMM')} at {b.time}</p>
-              <p>⏱ {b.serviceDuration} min · €{b.servicePrice}</p>
+              <p>📅 {format(parseISO(bk.date), 'EEE d MMM')} at {bk.time}</p>
+              <p>⏱ {bk.serviceDuration} min · €{bk.servicePrice}</p>
               {member && <p>👤 {member.name}</p>}
-              <p>📧 {b.customerEmail}</p>
-              <p>📞 {b.customerPhone}</p>
-              {b.customerNotes && <p>📝 {b.customerNotes}</p>}
+              <p>📧 {bk.customerEmail}</p>
+              <p>📞 {bk.customerPhone}</p>
+              {bk.customerNotes && <p>📝 {bk.customerNotes}</p>}
             </div>
             <Link href="/admin/bookings"
               className="mt-4 block text-center text-xs font-medium text-indigo-600 hover:underline">Manage booking →</Link>

--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -1,9 +1,8 @@
 'use client'
-import { useState } from 'react'
-import { services as initialServices } from '@/data/mock'
+import { useState, useEffect } from 'react'
+import type { Service } from '@/data/mock'
+import { loadServices, saveServices } from '@/lib/servicesStore'
 import { Clock } from 'lucide-react'
-
-type Service = typeof initialServices[0]
 
 const toForm = (s?: Service) => ({
   name: s?.name ?? '',
@@ -13,10 +12,17 @@ const toForm = (s?: Service) => ({
 })
 
 export default function ServicesPage() {
-  const [services, setServices] = useState<Service[]>(initialServices)
+  const [services, setServices] = useState<Service[]>([])
   const [showModal, setShowModal] = useState(false)
   const [editing, setEditing] = useState<Service | null>(null)
   const [form, setForm] = useState(toForm())
+
+  useEffect(() => { setServices(loadServices()) }, [])
+
+  const persist = (updated: Service[]) => {
+    setServices(updated)
+    saveServices(updated)
+  }
 
   const openCreate = () => { setForm(toForm()); setEditing(null); setShowModal(true) }
   const openEdit = (s: Service) => { setForm(toForm(s)); setEditing(s); setShowModal(true) }
@@ -29,15 +35,15 @@ export default function ServicesPage() {
       price: Math.max(0, parseFloat(form.price) || 0),
     }
     if (editing) {
-      setServices(prev => prev.map(s => s.id === editing.id ? { ...s, ...parsed } : s))
+      persist(services.map(s => s.id === editing.id ? { ...s, ...parsed } : s))
     } else {
-      setServices(prev => [...prev, { ...parsed, id: `s${Date.now()}`, currency: 'EUR' }])
+      persist([...services, { ...parsed, id: `s${Date.now()}`, currency: 'EUR' }])
     }
     setShowModal(false)
   }
 
   const handleDelete = (id: string) => {
-    if (confirm('Delete this service?')) setServices(prev => prev.filter(s => s.id !== id))
+    if (confirm('Delete this service?')) persist(services.filter(s => s.id !== id))
   }
 
   return (
@@ -53,7 +59,6 @@ export default function ServicesPage() {
         </button>
       </div>
 
-      {/* Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
           <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6">
@@ -74,25 +79,19 @@ export default function ServicesPage() {
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1.5">Duration (minutes)</label>
-                  <input
-                    type="number"
-                    value={form.duration}
+                  <input type="number" value={form.duration}
                     onChange={e => setForm(p => ({ ...p, duration: e.target.value }))}
                     onFocus={e => e.target.select()}
                     className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors"
-                    min={5} step={5}
-                  />
+                    min={5} step={5} />
                 </div>
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1.5">Price (€)</label>
-                  <input
-                    type="number"
-                    value={form.price}
+                  <input type="number" value={form.price}
                     onChange={e => setForm(p => ({ ...p, price: e.target.value }))}
                     onFocus={e => e.target.select()}
                     className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors"
-                    min={0} step={0.5}
-                  />
+                    min={0} step={0.5} />
                 </div>
               </div>
             </div>

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client'
-import { useState } from 'react'
-import { businessSettings } from '@/data/mock'
+import { useState, useEffect } from 'react'
+import { loadSettings, saveSettings } from '@/lib/settingsStore'
 import { Copy, Check, QrCode, Globe, MessageCircle, MapPin, ExternalLink, Code2 } from 'lucide-react'
 
 const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -25,8 +25,10 @@ function CopyButton({ text }: { text: string }) {
 }
 
 export default function SettingsPage() {
-  const [settings, setSettings] = useState({ ...businessSettings })
+  const [settings, setSettings] = useState(loadSettings())
   const [saved, setSaved] = useState(false)
+
+  useEffect(() => { setSettings(loadSettings()) }, [])
 
   const bookingUrl = `https://bookflow.app/book/demo`
   const iframeCode = `<iframe src="${bookingUrl}" width="100%" height="700" frameborder="0" style="border-radius:16px"></iframe>`
@@ -44,6 +46,7 @@ export default function SettingsPage() {
   }
 
   const handleSave = () => {
+    saveSettings(settings)
     setSaved(true)
     setTimeout(() => setSaved(false), 3000)
   }
@@ -56,24 +59,17 @@ export default function SettingsPage() {
       </div>
 
       <div className="space-y-6">
-
-        {/* ── SHARE & DISTRIBUTE ── */}
         <section className="bg-white rounded-2xl border-2 border-indigo-100 p-6 shadow-soft">
           <h2 className="font-semibold text-gray-900 mb-1">🔗 Share & distribute</h2>
           <p className="text-sm text-gray-400 mb-5">Get your booking page in front of customers — wherever they are</p>
-
           <div className="space-y-5">
-
-            {/* Direct link */}
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <Globe className="w-4 h-4 text-indigo-500" />
                 <span className="text-sm font-medium text-gray-700">Your booking link</span>
               </div>
               <div className="flex items-center gap-2">
-                <div className="flex-1 bg-gray-50 border-2 border-gray-100 rounded-xl px-4 py-2.5 text-sm font-mono text-indigo-600 truncate">
-                  {bookingUrl}
-                </div>
+                <div className="flex-1 bg-gray-50 border-2 border-gray-100 rounded-xl px-4 py-2.5 text-sm font-mono text-indigo-600 truncate">{bookingUrl}</div>
                 <CopyButton text={bookingUrl} />
                 <a href={bookingUrl} target="_blank"
                   className="flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-colors">
@@ -81,8 +77,6 @@ export default function SettingsPage() {
                 </a>
               </div>
             </div>
-
-            {/* QR Code */}
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <QrCode className="w-4 h-4 text-indigo-500" />
@@ -103,8 +97,6 @@ export default function SettingsPage() {
                 </div>
               </div>
             </div>
-
-            {/* Embed on website */}
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <Code2 className="w-4 h-4 text-indigo-500" />
@@ -114,15 +106,11 @@ export default function SettingsPage() {
               <div className="bg-gray-50 border-2 border-gray-100 rounded-xl p-4">
                 <div className="flex items-start justify-between gap-3">
                   <code className="text-xs text-gray-600 leading-relaxed break-all flex-1 font-mono">{iframeCode}</code>
-                  <div className="flex-shrink-0">
-                    <CopyButton text={iframeCode} />
-                  </div>
+                  <div className="flex-shrink-0"><CopyButton text={iframeCode} /></div>
                 </div>
               </div>
               <p className="text-xs text-gray-400 mt-2">Paste this anywhere in your website HTML where you want the booking form to appear.</p>
             </div>
-
-            {/* WhatsApp */}
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <MessageCircle className="w-4 h-4 text-green-500" />
@@ -138,17 +126,13 @@ export default function SettingsPage() {
                 <div className="border-t border-green-100 pt-3">
                   <p className="text-xs font-medium text-gray-600 mb-2">Option B — Click-to-chat link (share anywhere)</p>
                   <div className="flex items-center gap-2">
-                    <div className="flex-1 bg-white border border-green-200 rounded-lg px-3 py-2 text-xs font-mono text-green-700 truncate">
-                      {whatsappLink}
-                    </div>
+                    <div className="flex-1 bg-white border border-green-200 rounded-lg px-3 py-2 text-xs font-mono text-green-700 truncate">{whatsappLink}</div>
                     <CopyButton text={whatsappLink} />
                   </div>
                   <p className="text-xs text-gray-400 mt-1.5">When tapped, opens WhatsApp with a pre-filled message ready to send to you.</p>
                 </div>
               </div>
             </div>
-
-            {/* Google Maps */}
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <MapPin className="w-4 h-4 text-red-400" />
@@ -165,18 +149,14 @@ export default function SettingsPage() {
                   </ol>
                 </div>
                 <div className="flex items-center gap-2 pt-1">
-                  <div className="flex-1 bg-white border border-red-200 rounded-lg px-3 py-2 text-xs font-mono text-red-700 truncate">
-                    {bookingUrl}
-                  </div>
+                  <div className="flex-1 bg-white border border-red-200 rounded-lg px-3 py-2 text-xs font-mono text-red-700 truncate">{bookingUrl}</div>
                   <CopyButton text={bookingUrl} />
                 </div>
               </div>
             </div>
-
           </div>
         </section>
 
-        {/* Business Info */}
         <section className="bg-white rounded-2xl border-2 border-gray-100 p-6 shadow-soft">
           <h2 className="font-semibold text-gray-900 mb-4">🏢 Business information</h2>
           <div className="space-y-4">
@@ -210,7 +190,6 @@ export default function SettingsPage() {
           </div>
         </section>
 
-        {/* Schedule */}
         <section className="bg-white rounded-2xl border-2 border-gray-100 p-6 shadow-soft">
           <h2 className="font-semibold text-gray-900 mb-4">📅 Schedule</h2>
           <div className="space-y-5">
@@ -259,7 +238,6 @@ export default function SettingsPage() {
           </div>
         </section>
 
-        {/* Booking Rules */}
         <section className="bg-white rounded-2xl border-2 border-gray-100 p-6 shadow-soft">
           <h2 className="font-semibold text-gray-900 mb-4">⚙️ Booking rules</h2>
           <div className="grid grid-cols-2 gap-4">

--- a/src/app/admin/staff/page.tsx
+++ b/src/app/admin/staff/page.tsx
@@ -1,7 +1,8 @@
 'use client'
-import { useState } from 'react'
-import { staff as initialStaff, services } from '@/data/mock'
+import { useState, useEffect } from 'react'
+import { services } from '@/data/mock'
 import type { StaffMember } from '@/data/mock'
+import { loadStaff, saveStaff } from '@/lib/staffStore'
 import { Clock, Plus, X, Search } from 'lucide-react'
 
 const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -16,11 +17,18 @@ const emptyForm = {
 }
 
 export default function StaffPage() {
-  const [members, setMembers] = useState<StaffMember[]>(initialStaff)
+  const [members, setMembers] = useState<StaffMember[]>([])
   const [showModal, setShowModal] = useState(false)
   const [editing, setEditing] = useState<StaffMember | null>(null)
   const [form, setForm] = useState({ ...emptyForm })
   const [skillSearch, setSkillSearch] = useState('')
+
+  useEffect(() => { setMembers(loadStaff()) }, [])
+
+  const persist = (updated: StaffMember[]) => {
+    setMembers(updated)
+    saveStaff(updated)
+  }
 
   const openCreate = () => { setForm({ ...emptyForm }); setEditing(null); setSkillSearch(''); setShowModal(true) }
   const openEdit = (m: StaffMember) => {
@@ -36,21 +44,20 @@ export default function StaffPage() {
 
   const handleSave = () => {
     if (editing) {
-      setMembers(prev => prev.map(m => m.id === editing.id ? { ...m, ...form } : m))
+      persist(members.map(m => m.id === editing.id ? { ...m, ...form } : m))
     } else {
-      setMembers(prev => [...prev, { ...form, id: `st${Date.now()}` }])
+      persist([...members, { ...form, id: `st${Date.now()}` }])
     }
     setShowModal(false)
   }
 
   const handleDelete = (id: string) => {
-    if (confirm('Remove this staff member?')) setMembers(prev => prev.filter(m => m.id !== id))
+    if (confirm('Remove this staff member?')) persist(members.filter(m => m.id !== id))
   }
 
   const toggleActive = (id: string) =>
-    setMembers(prev => prev.map(m => m.id === id ? { ...m, active: !m.active } : m))
+    persist(members.map(m => m.id === id ? { ...m, active: !m.active } : m))
 
-  // Filtered services for skill search
   const filteredServices = services.filter(s =>
     s.name.toLowerCase().includes(skillSearch.toLowerCase())
   )
@@ -68,7 +75,6 @@ export default function StaffPage() {
         </button>
       </div>
 
-      {/* Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black/40 z-50 flex items-start justify-center p-4 overflow-y-auto">
           <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg p-6 my-8">
@@ -76,9 +82,7 @@ export default function StaffPage() {
               <h2 className="text-lg font-bold text-gray-900">{editing ? 'Edit staff member' : 'New staff member'}</h2>
               <button onClick={() => setShowModal(false)} className="text-gray-400 hover:text-gray-700"><X className="w-5 h-5" /></button>
             </div>
-
             <div className="space-y-5">
-              {/* Avatar color */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">Avatar colour</label>
                 <div className="flex gap-2">
@@ -89,14 +93,12 @@ export default function StaffPage() {
                         form.color === c ? 'ring-2 ring-offset-2 ring-gray-400 scale-110' : 'hover:scale-105'
                       }`} />
                   ))}
-                  {/* Preview */}
                   <div className="ml-3 w-10 h-10 rounded-xl flex items-center justify-center text-white font-bold text-sm"
                     style={{ backgroundColor: form.color }}>
                     {form.name ? form.name.split(' ').map(n => n[0]).join('').slice(0, 2) : 'AB'}
                   </div>
                 </div>
               </div>
-
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1.5">Full name</label>
@@ -111,15 +113,12 @@ export default function StaffPage() {
                     placeholder="e.g. Senior Therapist" />
                 </div>
               </div>
-
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1.5">Bio <span className="text-gray-400 font-normal">(optional)</span></label>
                 <textarea value={form.bio} onChange={e => setForm(p => ({ ...p, bio: e.target.value }))}
                   className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors resize-none"
                   rows={2} placeholder="Short description shown to customers" />
               </div>
-
-              {/* Skills / Services — dynamic from services list */}
               <div>
                 <div className="flex items-center justify-between mb-2">
                   <label className="text-sm font-medium text-gray-700">Skills <span className="text-gray-400 font-normal text-xs">(services from your catalogue)</span></label>
@@ -127,8 +126,6 @@ export default function StaffPage() {
                     <span className="text-xs text-indigo-600 font-medium">{form.serviceIds.length} selected</span>
                   )}
                 </div>
-
-                {/* Selected skills as tags */}
                 {form.serviceIds.length > 0 && (
                   <div className="flex flex-wrap gap-1.5 mb-2">
                     {form.serviceIds.map(id => {
@@ -144,17 +141,12 @@ export default function StaffPage() {
                     })}
                   </div>
                 )}
-
-                {/* Search + add */}
                 <div className="border-2 border-gray-100 rounded-xl overflow-hidden focus-within:border-indigo-400 transition-colors">
                   <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-50">
                     <Search className="w-3.5 h-3.5 text-gray-300" />
-                    <input
-                      value={skillSearch}
-                      onChange={e => setSkillSearch(e.target.value)}
+                    <input value={skillSearch} onChange={e => setSkillSearch(e.target.value)}
                       placeholder="Search services..."
-                      className="flex-1 text-sm outline-none text-gray-700 placeholder-gray-300 bg-transparent"
-                    />
+                      className="flex-1 text-sm outline-none text-gray-700 placeholder-gray-300 bg-transparent" />
                   </div>
                   <div className="max-h-36 overflow-y-auto">
                     {filteredServices.filter(s => !form.serviceIds.includes(s.id)).map(s => (
@@ -171,8 +163,6 @@ export default function StaffPage() {
                 </div>
                 <p className="text-xs text-gray-400 mt-1.5">Services are pulled from your Services page — add new ones there first.</p>
               </div>
-
-              {/* Work days */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">Working days</label>
                 <div className="flex gap-2">
@@ -188,8 +178,6 @@ export default function StaffPage() {
                   ))}
                 </div>
               </div>
-
-              {/* Work hours */}
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1.5">Start time</label>
@@ -203,7 +191,6 @@ export default function StaffPage() {
                 </div>
               </div>
             </div>
-
             <div className="flex gap-3 mt-6">
               <button onClick={handleSave} disabled={!form.name || !form.role || form.serviceIds.length === 0}
                 className="flex-1 bg-indigo-600 text-white py-2.5 rounded-xl font-medium hover:bg-indigo-700 disabled:opacity-40 transition-colors">
@@ -216,7 +203,6 @@ export default function StaffPage() {
         </div>
       )}
 
-      {/* Staff grid */}
       <div className="grid gap-4">
         {members.map(m => {
           const memberServices = services.filter(s => m.serviceIds.includes(s.id))

--- a/src/app/book/[slug]/page.tsx
+++ b/src/app/book/[slug]/page.tsx
@@ -1,8 +1,11 @@
 'use client'
-import { useState } from 'react'
-import { businessSettings, services, staff } from '@/data/mock'
+import { useState, useEffect } from 'react'
+import { services as mockServices } from '@/data/mock'
+import { loadStaff } from '@/lib/staffStore'
+import { loadSettings } from '@/lib/settingsStore'
 import { getSlotsForDate, getAvailableDates } from '@/lib/slots'
-import { saveBooking } from '@/lib/bookingsStore'
+import { saveBooking, loadBookings } from '@/lib/bookingsStore'
+import type { StaffMember, Service } from '@/data/mock'
 import { format, parseISO } from 'date-fns'
 import { Clock, CheckCircle, MapPin, Phone, Mail, ChevronLeft, Users } from 'lucide-react'
 
@@ -32,13 +35,22 @@ const validatePhone = (v: string) => {
 
 export default function BookingPage() {
   const [step, setStep] = useState<Step>('service')
-  const [selectedService, setSelectedService] = useState<typeof services[0] | null>(null)
+  const [selectedService, setSelectedService] = useState<Service | null>(null)
   const [selectedStaffId, setSelectedStaffId] = useState<string>('any')
   const [selectedDate, setSelectedDate] = useState('')
   const [selectedTime, setSelectedTime] = useState('')
   const [form, setForm] = useState({ name: '', email: '', phone: '', notes: '' })
   const [touched, setTouched] = useState({ name: false, email: false, phone: false })
   const [bookingRef] = useState(() => 'BF-' + Math.random().toString(36).substring(2, 8).toUpperCase())
+
+  const [services, setServices] = useState<Service[]>(mockServices)
+  const [staffMembers, setStaffMembers] = useState<StaffMember[]>([])
+  const [b, setB] = useState(loadSettings())
+
+  useEffect(() => {
+    setStaffMembers(loadStaff())
+    setB(loadSettings())
+  }, [])
 
   const errors = {
     name: validateName(form.name),
@@ -64,19 +76,30 @@ export default function BookingPage() {
         : 'border-gray-100 focus:border-indigo-400'
     }`
 
-  const b = businessSettings
   const availableDates = getAvailableDates()
-  const bookedSlots = ['10:00', '11:00', '14:00']
+
+  // Real booked slots from the store for selected date + staff
+  const bookedSlots = selectedService && selectedDate
+    ? loadBookings()
+        .filter(bk =>
+          bk.date === selectedDate &&
+          bk.status !== 'cancelled' &&
+          (selectedStaffId === 'any' || bk.staffId === selectedStaffId)
+        )
+        .map(bk => bk.time)
+    : []
+
+  const selectedStaffMember = selectedStaffId !== 'any'
+    ? staffMembers.find(m => m.id === selectedStaffId) ?? null
+    : null
+
   const slots = selectedService && selectedDate
-    ? getSlotsForDate(selectedDate, selectedService.duration, bookedSlots)
+    ? getSlotsForDate(selectedDate, selectedService.duration, bookedSlots, selectedStaffMember)
     : []
 
   const availableStaff = selectedService
-    ? staff.filter(m => m.active && m.serviceIds.includes(selectedService.id))
+    ? staffMembers.filter(m => m.active && m.serviceIds.includes(selectedService.id))
     : []
-  const selectedStaffMember = selectedStaffId !== 'any'
-    ? staff.find(m => m.id === selectedStaffId)
-    : null
 
   const stepKeys: Step[] = ['service', 'staff', 'datetime', 'details', 'confirm']
   const stepIndex = stepKeys.indexOf(step)
@@ -274,6 +297,9 @@ export default function BookingPage() {
                       {slot.time}
                     </button>
                   ))}
+                  {slots.length === 0 && selectedDate && (
+                    <p className="col-span-full text-sm text-gray-400 text-center py-4">No available slots for this date.</p>
+                  )}
                 </div>
               </div>
             )}
@@ -290,75 +316,40 @@ export default function BookingPage() {
                 <label className="block text-sm font-medium text-gray-700 mb-1.5">
                   Full name <span className="text-red-400">*</span>
                 </label>
-                <input
-                  value={form.name}
-                  onChange={e => setForm(p => ({ ...p, name: e.target.value }))}
-                  onBlur={() => touch('name')}
-                  className={fieldClass('name')}
-                  placeholder="e.g. Anna Bērziņa"
-                />
-                {touched.name && errors.name && (
-                  <p className="text-xs text-red-500 mt-1.5">⚠ {errors.name}</p>
-                )}
-                {touched.name && !errors.name && (
-                  <p className="text-xs text-green-600 mt-1.5">✓ Looks good</p>
-                )}
+                <input value={form.name} onChange={e => setForm(p => ({ ...p, name: e.target.value }))}
+                  onBlur={() => touch('name')} className={fieldClass('name')} placeholder="e.g. Anna Bērziņa" />
+                {touched.name && errors.name && <p className="text-xs text-red-500 mt-1.5">⚠ {errors.name}</p>}
+                {touched.name && !errors.name && <p className="text-xs text-green-600 mt-1.5">✓ Looks good</p>}
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1.5">
                   Email address <span className="text-red-400">*</span>
                 </label>
-                <input
-                  type="email"
-                  value={form.email}
-                  onChange={e => setForm(p => ({ ...p, email: e.target.value }))}
-                  onBlur={() => touch('email')}
-                  className={fieldClass('email')}
-                  placeholder="anna@example.com"
-                />
-                {touched.email && errors.email && (
-                  <p className="text-xs text-red-500 mt-1.5">⚠ {errors.email}</p>
-                )}
-                {touched.email && !errors.email && (
-                  <p className="text-xs text-green-600 mt-1.5">✓ Looks good</p>
-                )}
+                <input type="email" value={form.email} onChange={e => setForm(p => ({ ...p, email: e.target.value }))}
+                  onBlur={() => touch('email')} className={fieldClass('email')} placeholder="anna@example.com" />
+                {touched.email && errors.email && <p className="text-xs text-red-500 mt-1.5">⚠ {errors.email}</p>}
+                {touched.email && !errors.email && <p className="text-xs text-green-600 mt-1.5">✓ Looks good</p>}
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1.5">
                   Phone number <span className="text-red-400">*</span>
                 </label>
-                <input
-                  type="tel"
-                  value={form.phone}
-                  onChange={e => setForm(p => ({ ...p, phone: e.target.value }))}
-                  onBlur={() => touch('phone')}
-                  className={fieldClass('phone')}
-                  placeholder="+371 2612 3456"
-                />
-                {touched.phone && errors.phone && (
-                  <p className="text-xs text-red-500 mt-1.5">⚠ {errors.phone}</p>
-                )}
-                {touched.phone && !errors.phone && (
-                  <p className="text-xs text-green-600 mt-1.5">✓ Looks good</p>
-                )}
+                <input type="tel" value={form.phone} onChange={e => setForm(p => ({ ...p, phone: e.target.value }))}
+                  onBlur={() => touch('phone')} className={fieldClass('phone')} placeholder="+371 2612 3456" />
+                {touched.phone && errors.phone && <p className="text-xs text-red-500 mt-1.5">⚠ {errors.phone}</p>}
+                {touched.phone && !errors.phone && <p className="text-xs text-green-600 mt-1.5">✓ Looks good</p>}
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1.5">
                   Notes <span className="text-gray-400 font-normal">(optional)</span>
                 </label>
-                <textarea
-                  value={form.notes}
-                  onChange={e => setForm(p => ({ ...p, notes: e.target.value }))}
+                <textarea value={form.notes} onChange={e => setForm(p => ({ ...p, notes: e.target.value }))}
                   className="w-full border-2 border-gray-100 rounded-xl px-4 py-3 focus:outline-none focus:border-indigo-400 transition-colors resize-none"
-                  rows={3}
-                  placeholder="Any special requests or things we should know?"
-                />
+                  rows={3} placeholder="Any special requests or things we should know?" />
               </div>
             </div>
-            <button
-              onClick={handleNext}
-              className="mt-6 w-full bg-indigo-600 text-white py-4 rounded-xl font-semibold hover:bg-indigo-700 transition-colors"
-            >
+            <button onClick={handleNext}
+              className="mt-6 w-full bg-indigo-600 text-white py-4 rounded-xl font-semibold hover:bg-indigo-700 transition-colors">
               Review booking →
             </button>
           </div>
@@ -397,8 +388,7 @@ export default function BookingPage() {
             <div className="bg-amber-50 border border-amber-100 rounded-xl px-4 py-3 mb-5">
               <p className="text-xs text-amber-700"><span className="font-semibold">Cancellation policy:</span> {b.cancellationPolicy}</p>
             </div>
-            <button
-              onClick={handleConfirm}
+            <button onClick={handleConfirm}
               className="w-full bg-indigo-600 text-white py-4 rounded-xl font-semibold hover:bg-indigo-700 transition-colors">
               Confirm booking ✓
             </button>

--- a/src/lib/bookingsStore.ts
+++ b/src/lib/bookingsStore.ts
@@ -1,4 +1,6 @@
-export type BookingStatus = 'confirmed' | 'cancelled' | 'completed'
+import { bookings as mockBookings } from '@/data/mock'
+
+export type BookingStatus = 'confirmed' | 'cancelled' | 'completed' | 'pending'
 
 export interface Booking {
   id: string
@@ -30,8 +32,36 @@ export interface Booking {
 
 const KEY = 'bf_bookings'
 
+function seedIfEmpty(): void {
+  if (typeof window === 'undefined') return
+  const raw = localStorage.getItem(KEY)
+  if (!raw) {
+    // Map mock bookings to the canonical Booking interface
+    const seeded: Booking[] = mockBookings.map(b => ({
+      id: b.id,
+      ref: `BF-${b.id.toUpperCase()}`,
+      createdAt: b.createdAt,
+      serviceId: b.serviceId,
+      serviceName: b.service,
+      serviceDuration: 60,
+      servicePrice: 0,
+      staffId: b.staffId,
+      staffName: b.staffName,
+      date: b.date,
+      time: b.time,
+      customerName: b.customerName,
+      customerEmail: b.customerEmail,
+      customerPhone: b.customerPhone,
+      customerNotes: b.notes,
+      status: b.status as BookingStatus,
+    }))
+    localStorage.setItem(KEY, JSON.stringify(seeded))
+  }
+}
+
 export function loadBookings(): Booking[] {
   if (typeof window === 'undefined') return []
+  seedIfEmpty()
   try {
     const raw = localStorage.getItem(KEY)
     return raw ? (JSON.parse(raw) as Booking[]) : []
@@ -42,7 +72,6 @@ export function loadBookings(): Booking[] {
 
 export function saveBooking(booking: Booking): void {
   const all = loadBookings()
-  // Replace if ref already exists, otherwise append
   const idx = all.findIndex(b => b.ref === booking.ref)
   if (idx >= 0) {
     all[idx] = booking

--- a/src/lib/servicesStore.ts
+++ b/src/lib/servicesStore.ts
@@ -1,0 +1,22 @@
+import type { Service } from '@/data/mock'
+import { services as mockServices } from '@/data/mock'
+
+const KEY = 'bf_services'
+
+export function loadServices(): Service[] {
+  if (typeof window === 'undefined') return mockServices
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (raw) return JSON.parse(raw) as Service[]
+    // First run — seed from mock
+    localStorage.setItem(KEY, JSON.stringify(mockServices))
+    return mockServices
+  } catch {
+    return mockServices
+  }
+}
+
+export function saveServices(services: Service[]): void {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(KEY, JSON.stringify(services))
+}

--- a/src/lib/settingsStore.ts
+++ b/src/lib/settingsStore.ts
@@ -1,0 +1,22 @@
+import type { BusinessSettings } from '@/data/mock'
+import { businessSettings as mockSettings } from '@/data/mock'
+
+const KEY = 'bf_settings'
+
+export function loadSettings(): BusinessSettings {
+  if (typeof window === 'undefined') return mockSettings
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (raw) return JSON.parse(raw) as BusinessSettings
+    // First run — seed from mock
+    localStorage.setItem(KEY, JSON.stringify(mockSettings))
+    return mockSettings
+  } catch {
+    return mockSettings
+  }
+}
+
+export function saveSettings(settings: BusinessSettings): void {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(KEY, JSON.stringify(settings))
+}

--- a/src/lib/slots.ts
+++ b/src/lib/slots.ts
@@ -1,13 +1,15 @@
-import { businessSettings } from '@/data/mock'
-import { addDays, format, parseISO, isBefore, addMinutes } from 'date-fns'
+import { loadSettings } from '@/lib/settingsStore'
+import type { StaffMember } from '@/data/mock'
+import { addDays, format, isBefore } from 'date-fns'
 
 export function getAvailableDates(): string[] {
+  const settings = loadSettings()
   const dates: string[] = []
   const today = new Date()
-  const max = addDays(today, businessSettings.maxAdvanceDays)
-  let cursor = addDays(today, 0)
+  const max = addDays(today, settings.maxAdvanceDays)
+  let cursor = new Date(today)
   while (isBefore(cursor, max)) {
-    if (businessSettings.openDays.includes(cursor.getDay())) {
+    if (settings.openDays.includes(cursor.getDay())) {
       dates.push(format(cursor, 'yyyy-MM-dd'))
     }
     cursor = addDays(cursor, 1)
@@ -15,12 +17,29 @@ export function getAvailableDates(): string[] {
   return dates
 }
 
-export function getSlotsForDate(date: string, durationMins: number, bookedSlots: string[]): { time: string; available: boolean }[] {
-  const [openH, openM] = businessSettings.openTime.split(':').map(Number)
-  const [closeH, closeM] = businessSettings.closeTime.split(':').map(Number)
+export function getSlotsForDate(
+  date: string,
+  durationMins: number,
+  bookedSlots: string[],
+  staffMember?: StaffMember | null
+): { time: string; available: boolean }[] {
+  const settings = loadSettings()
+
+  // Use staff-specific hours if a staff member is selected
+  const startTime = staffMember ? staffMember.workStart : settings.openTime
+  const endTime = staffMember ? staffMember.workEnd : settings.closeTime
+
+  // If staff member doesn't work on this day, return no slots
+  if (staffMember) {
+    const dayOfWeek = new Date(date + 'T12:00:00').getDay()
+    if (!staffMember.workDays.includes(dayOfWeek)) return []
+  }
+
+  const [openH, openM] = startTime.split(':').map(Number)
+  const [closeH, closeM] = endTime.split(':').map(Number)
   const openMins = openH * 60 + openM
   const closeMins = closeH * 60 + closeM
-  const interval = businessSettings.slotInterval
+  const interval = settings.slotInterval
   const slots: { time: string; available: boolean }[] = []
 
   for (let m = openMins; m + durationMins <= closeMins; m += interval) {

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -1,0 +1,22 @@
+import type { StaffMember } from '@/data/mock'
+import { staff as mockStaff } from '@/data/mock'
+
+const KEY = 'bf_staff'
+
+export function loadStaff(): StaffMember[] {
+  if (typeof window === 'undefined') return mockStaff
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (raw) return JSON.parse(raw) as StaffMember[]
+    // First run — seed from mock
+    localStorage.setItem(KEY, JSON.stringify(mockStaff))
+    return mockStaff
+  } catch {
+    return mockStaff
+  }
+}
+
+export function saveStaff(staff: StaffMember[]): void {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(KEY, JSON.stringify(staff))
+}


### PR DESCRIPTION
## Summary

Fixes all 5 bugs identified in Issue #1.

Closes #1

---

## Changes

### New files
| File | Purpose |
|---|---|
| `src/lib/servicesStore.ts` | localStorage persistence for services (`bf_services`) |
| `src/lib/staffStore.ts` | localStorage persistence for staff (`bf_staff`) |
| `src/lib/settingsStore.ts` | localStorage persistence for settings (`bf_settings`) |

### Updated files
| File | What changed |
|---|---|
| `src/lib/slots.ts` | Accepts optional `staffMember` param — uses staff-specific `workStart`/`workEnd`/`workDays` when provided |
| `src/lib/bookingsStore.ts` | Reconciled `Booking` type (single canonical interface); seeds mock bookings into localStorage on first run |
| `src/app/book/[slug]/page.tsx` | `bookedSlots` now reads from real bookings store (not hardcoded); passes selected staff member to slot generator |
| `src/app/admin/page.tsx` | `pendingCount` calculated from real booking statuses; `totalRevenue` computed from confirmed/completed bookings |
| `src/app/admin/services/page.tsx` | Loads from + saves to `servicesStore` on every create/edit/delete |
| `src/app/admin/staff/page.tsx` | Loads from + saves to `staffStore` on every create/edit/delete/toggle |
| `src/app/admin/settings/page.tsx` | Loads from + saves to `settingsStore` on save |

---

## Bug fixes checklist

- [x] Booked time slots read from bookings store, not hardcoded
- [x] Slot picker respects selected staff member's working hours and work days
- [x] Service edits persist on page refresh
- [x] Staff edits persist on page refresh
- [x] Settings edits persist on page refresh
- [x] 'Pending confirmation' stat reflects real pending booking count
- [x] Single shared `Booking` type across the codebase
- [x] Mock bookings from `mock.ts` visible in admin dashboard (seeded on first run)

---

## Testing

1. Open `/book/demo` → complete a booking → re-open the booking wizard for the same date/staff — the booked slot should now show as unavailable
2. Go to `/admin/services` → edit a service name → refresh the page — the name should persist
3. Go to `/admin/staff` → edit a staff member → refresh — changes should persist
4. Go to `/admin/settings` → change opening time → save → refresh — the new time should persist
5. Go to `/admin` — the 'Pending confirmation' stat should show a non-zero number
6. Open `/admin` on a fresh browser (or clear localStorage) — mock bookings should appear in the calendar