### PR TITLE
fix(security): throw on missing secret, server-side bookingRef, rate limit /api/book

### DIFF
--- a/src/app/api/book/route.ts
+++ b/src/app/api/book/route.ts
@@ -3,16 +3,34 @@ import { z } from 'zod'
 import { Resend } from 'resend'
 import { createClient } from '@/lib/supabase/server'
 import { generateCancelToken } from '@/lib/cancel-token'
+import { randomBytes } from 'crypto'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
+// ─── Simple in-memory rate limiter (per IP, resets every minute) ──────────────
+// For production scale, replace with @upstash/ratelimit + Redis.
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>()
+const RATE_LIMIT_MAX      = 10   // max bookings per window
+const RATE_LIMIT_WINDOW   = 60_000 // 1 minute in ms
+
+function isRateLimited(ip: string): boolean {
+  const now    = Date.now()
+  const record = rateLimitMap.get(ip)
+  if (!record || now > record.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW })
+    return false
+  }
+  record.count++
+  return record.count > RATE_LIMIT_MAX
+}
+
+// ─── Validation schema ────────────────────────────────────────────────────────
 const uuid       = z.string().uuid()
 const timeString = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Invalid time format (HH:MM expected)')
 const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (YYYY-MM-DD expected)')
 
 const BookingSchema = z.object({
   business_id:      uuid,
-  ref:              z.string().min(1).max(32),
   service_id:       uuid,
   service_name:     z.string().min(1).max(200),
   service_duration: z.number().int().min(5).max(480),
@@ -29,7 +47,7 @@ const BookingSchema = z.object({
 
 type BookingBody = z.infer<typeof BookingSchema>
 
-// ─── Email templates ──────────────────────────────────────────
+// ─── Email templates ──────────────────────────────────────────────────────────
 
 function customerEmailHtml(p: {
   businessName: string
@@ -198,10 +216,19 @@ function adminEmailHtml(p: {
 </html>`
 }
 
-// ─── Route handler ────────────────────────────────────────────
+// ─── Route handler ────────────────────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
   try {
+    // ── Rate limiting ─────────────────────────────────────────────────────────
+    const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+    if (isRateLimited(ip)) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please wait a moment and try again.' },
+        { status: 429 }
+      )
+    }
+
     const raw = await req.json()
 
     const parsed = BookingSchema.safeParse(raw)
@@ -225,11 +252,14 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Business not found' }, { status: 404 })
     }
 
+    // ── Generate booking ref server-side with crypto randomness ───────────────
+    const ref = 'BF-' + randomBytes(4).toString('hex').toUpperCase()
+
     const { data: booking, error: bookingError } = await supabase
       .from('bookings')
       .insert({
         business_id:      body.business_id,
-        ref:              body.ref,
+        ref,
         service_id:       body.service_id,
         service_name:     body.service_name,
         service_duration: body.service_duration,
@@ -269,7 +299,6 @@ export async function POST(req: NextRequest) {
     const fromEmail  = `bookings@${fromDomain}`
     const adminEmail = businessEmail
 
-    // Build signed cancellation URL — no DB token needed
     const cancelToken = generateCancelToken(booking.id)
     const cancelUrl   = `${appUrl}/api/cancel?id=${booking.id}&token=${cancelToken}`
 
@@ -294,7 +323,7 @@ export async function POST(req: NextRequest) {
           time:               body.time,
           duration:           body.service_duration,
           price:              body.service_price,
-          ref:                body.ref,
+          ref:                booking.ref,
           cancellationPolicy: cancelPolicy,
           cancelUrl,
         }),
@@ -315,7 +344,7 @@ export async function POST(req: NextRequest) {
           time:          body.time,
           duration:      body.service_duration,
           price:         body.service_price,
-          ref:           body.ref,
+          ref:           booking.ref,
         }),
       })] : []),
     ])

--- a/src/app/book/[slug]/BookingWizard.tsx
+++ b/src/app/book/[slug]/BookingWizard.tsx
@@ -64,7 +64,8 @@ export default function BookingWizard({ business }: { business: Business }) {
   const [selectedTime, setSelectedTime]           = useState('')
   const [form, setForm]                           = useState<BookingForm>({ name: '', email: '', phone: '', notes: '' })
   const [touched, setTouched]                     = useState({ name: false, email: false, phone: false })
-  const [bookingRef]                              = useState(() => 'BF-' + Math.random().toString(36).substring(2, 8).toUpperCase())
+  // bookingRef is now generated server-side and returned in the /api/book response
+  const [bookingRef, setBookingRef]               = useState('')
   const [services, setServices]                   = useState<DBService[]>([])
   const [staffMembers, setStaffMembers]           = useState<DBStaffMember[]>([])
   const [bookedRaw, setBookedRaw]                 = useState<BookedSlotRaw[]>([])
@@ -127,7 +128,6 @@ export default function BookingWizard({ business }: { business: Business }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           business_id:      business.id,
-          ref:              bookingRef,
           service_id:       selectedService.id,
           service_name:     selectedService.name,
           service_duration: selectedService.duration,
@@ -144,6 +144,8 @@ export default function BookingWizard({ business }: { business: Business }) {
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data?.error ?? 'Booking failed')
+      // ref is now generated server-side and returned in the response
+      setBookingRef(data.booking.ref)
       setEmailSent(data.emailsSent === true)
       setStep('success')
     } catch (err) {

--- a/src/lib/cancel-token.ts
+++ b/src/lib/cancel-token.ts
@@ -1,7 +1,14 @@
 import { createHmac } from 'crypto'
 
-const SECRET = process.env.CANCEL_TOKEN_SECRET ?? process.env.SUPABASE_SERVICE_ROLE_KEY ?? 'fallback-secret'
+const secret = process.env.CANCEL_TOKEN_SECRET
+
+if (!secret) {
+  throw new Error(
+    'CANCEL_TOKEN_SECRET environment variable is not set. ' +
+    'Add it to your .env.local and Vercel project settings.'
+  )
+}
 
 export function generateCancelToken(bookingId: string): string {
-  return createHmac('sha256', SECRET).update(bookingId).digest('hex')
+  return createHmac('sha256', secret).update(bookingId).digest('hex')
 }


### PR DESCRIPTION
## What this fixes

Three security hardening issues from Issue #5.

---

### 1. `cancel-token.ts` — hard throw on missing `CANCEL_TOKEN_SECRET`

**Before:** `?? process.env.SUPABASE_SERVICE_ROLE_KEY ?? 'fallback-secret'`  
**After:** Throws a clear `Error` at module load time if the env var is missing.

A missing secret would previously cause all HMAC tokens to be computed with a known fallback string, making cancellation links trivially forgeable.

---

### 2. `bookingRef` moved server-side

**Before:** `'BF-' + Math.random().toString(36).substring(2, 8).toUpperCase()` — generated in the browser with non-cryptographic randomness, collision-prone at scale.

**After:** `'BF-' + randomBytes(4).toString('hex').toUpperCase()` — generated in `/api/book/route.ts` using Node's `crypto.randomBytes`, returned in the response, and set on the client via `setBookingRef(data.booking.ref)`.

The `ref` field has also been removed from the Zod `BookingSchema` (clients no longer send it — the server generates and owns it).

---

### 3. IP-based rate limiting on `POST /api/book`

**Before:** No rate limiting — any bot could flood bookings, exhausting Supabase row limits and Resend email quota.

**After:** In-memory rate limiter (10 requests / 60s per IP) using `x-forwarded-for`. Returns `429 Too Many Requests` when exceeded.

> **Note:** The in-memory map resets on serverless cold starts. For production scale with high traffic, replace with `@upstash/ratelimit` + a Redis store. For a typical small-business SaaS this is more than sufficient.

---

## Checklist
- [x] `CANCEL_TOKEN_SECRET` must be set in `.env.local` and Vercel — app will not start without it
- [x] No client-side changes to the booking UX — the ref is still shown on the success screen
- [x] All email templates still receive `booking.ref` (now from the DB row, not the request body)

Closes part of #5