### PR TITLE
feat(cancel): enforce cancellation_window_hours from business settings

### DIFF
--- a/src/app/admin/settings/_sections/BookingRulesSection.tsx
+++ b/src/app/admin/settings/_sections/BookingRulesSection.tsx
@@ -3,35 +3,65 @@
 interface Props {
   leadTimeHours: number
   maxAdvanceDays: number
+  cancellationWindowHours: number
   cancellationPolicy: string
   onChange: (field: string, value: string | number) => void
 }
 
-export default function BookingRulesSection({ leadTimeHours, maxAdvanceDays, cancellationPolicy, onChange }: Props) {
+export default function BookingRulesSection({
+  leadTimeHours,
+  maxAdvanceDays,
+  cancellationWindowHours,
+  cancellationPolicy,
+  onChange,
+}: Props) {
   return (
     <section className="bg-white rounded-2xl border-2 border-gray-100 p-6 shadow-soft">
       <h2 className="font-semibold text-gray-900 mb-4">⚙️ Booking rules</h2>
       <div className="grid grid-cols-2 gap-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1.5">Lead time (hours)</label>
-          <input type="number" value={leadTimeHours}
+          <input
+            type="number"
+            value={leadTimeHours}
             onChange={e => onChange('lead_time_hours', Number(e.target.value))}
-            className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors" min={0} />
+            className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors"
+            min={0}
+          />
           <p className="text-xs text-gray-400 mt-1">Min. hours before a booking can be made</p>
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1.5">Max advance (days)</label>
-          <input type="number" value={maxAdvanceDays}
+          <input
+            type="number"
+            value={maxAdvanceDays}
             onChange={e => onChange('max_advance_days', Number(e.target.value))}
-            className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors" min={1} />
+            className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors"
+            min={1}
+          />
           <p className="text-xs text-gray-400 mt-1">How far ahead clients can book</p>
+        </div>
+        <div className="col-span-2">
+          <label className="block text-sm font-medium text-gray-700 mb-1.5">Cancellation window (hours)</label>
+          <input
+            type="number"
+            value={cancellationWindowHours}
+            onChange={e => onChange('cancellation_window_hours', Number(e.target.value))}
+            className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors"
+            min={0}
+          />
+          <p className="text-xs text-gray-400 mt-1">How many hours before the appointment customers can still cancel online. Set to 0 to always allow cancellation.</p>
         </div>
       </div>
       <div className="mt-4">
         <label className="block text-sm font-medium text-gray-700 mb-1.5">Cancellation policy</label>
-        <textarea value={cancellationPolicy}
+        <textarea
+          value={cancellationPolicy}
           onChange={e => onChange('cancellation_policy', e.target.value)}
-          className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors resize-none" rows={2} />
+          className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 focus:outline-none focus:border-indigo-400 transition-colors resize-none"
+          rows={2}
+        />
+        <p className="text-xs text-gray-400 mt-1">This text is shown to customers in their confirmation email.</p>
       </div>
     </section>
   )

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -13,6 +13,7 @@ type Settings = {
   phone: string; email: string; slug: string
   open_days: number[]; open_time: string; close_time: string
   slot_interval: number; lead_time_hours: number; max_advance_days: number
+  cancellation_window_hours: number
   cancellation_policy: string; primary_color: string
   logo_url: string; cover_url: string
   instagram_url: string; facebook_url: string; tiktok_url: string; website_url: string
@@ -175,6 +176,7 @@ export default function SettingsPage() {
         <BookingRulesSection
           leadTimeHours={settings.lead_time_hours}
           maxAdvanceDays={settings.max_advance_days}
+          cancellationWindowHours={settings.cancellation_window_hours ?? 24}
           cancellationPolicy={settings.cancellation_policy}
           onChange={set}
         />

--- a/src/app/api/cancel/route.ts
+++ b/src/app/api/cancel/route.ts
@@ -54,7 +54,7 @@ export async function GET(req: NextRequest) {
 
   const { data: booking, error: fetchError } = await supabase
     .from('bookings')
-    .select('id, status, service_name, date, time, customer_name')
+    .select('id, status, service_name, date, time, customer_name, business_id')
     .eq('id', id)
     .single()
 
@@ -77,6 +77,37 @@ export async function GET(req: NextRequest) {
       html('Booking completed', 'This appointment has already been completed and cannot be cancelled.', true),
       { status: 400, headers: { 'Content-Type': 'text/html' } }
     )
+  }
+
+  // ── Cancellation window check ──────────────────────────────────────────────
+  const { data: biz } = await supabase
+    .from('business_settings')
+    .select('cancellation_window_hours')
+    .eq('id', booking.business_id)
+    .single()
+
+  const windowHours = biz?.cancellation_window_hours ?? 24
+
+  if (windowHours > 0) {
+    // Parse appointment datetime (date = 'YYYY-MM-DD', time = 'HH:MM')
+    const appointmentAt = new Date(`${booking.date}T${booking.time}:00`)
+    const deadlineAt    = new Date(appointmentAt.getTime() - windowHours * 60 * 60 * 1000)
+    const now           = new Date()
+
+    if (now >= deadlineAt) {
+      const deadlineStr = deadlineAt.toLocaleString('en-GB', {
+        day: 'numeric', month: 'long', year: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      })
+      return new NextResponse(
+        html(
+          'Cancellation deadline passed',
+          `This booking can no longer be cancelled online. The cancellation deadline was ${deadlineStr} (${windowHours} hour${windowHours === 1 ? '' : 's'} before your appointment). Please contact us directly if you need assistance.`,
+          true
+        ),
+        { status: 400, headers: { 'Content-Type': 'text/html' } }
+      )
+    }
   }
 
   const { error: updateError } = await supabase


### PR DESCRIPTION
## What this adds

Customers can no longer cancel their booking online once the cancellation window has passed.

### How it works

`/api/cancel/route.ts` now:
1. Fetches `business_settings.cancellation_window_hours` for the booking's business
2. Computes the cancellation deadline: `appointmentTime - windowHours`
3. If `now >= deadline` → returns a clear HTML error page telling the customer the deadline and asking them to contact the business directly
4. If `windowHours = 0` → cancellation is always allowed (no window enforced)
5. Falls back to `24` hours if the column is null (safe default)

### Admin UI

`BookingRulesSection` now has a **Cancellation window (hours)** number input, saved via the existing `/api/settings` PATCH route alongside all other settings.

### Files changed
- `src/app/api/cancel/route.ts` — window enforcement logic
- `src/app/admin/settings/_sections/BookingRulesSection.tsx` — new input field
- `src/app/admin/settings/page.tsx` — `cancellation_window_hours` added to `Settings` type and passed to `BookingRulesSection`

### DB prerequisite
✅ `cancellation_window_hours integer DEFAULT 24` column already added to `business_settings`.

Closes part of #5