### PR TITLE
feat(landing+seo): wire in TestimonialsSection, add dynamic metadata to /book/[slug]

### DIFF
--- a/src/app/book/[slug]/page.tsx
+++ b/src/app/book/[slug]/page.tsx
@@ -1,9 +1,56 @@
 import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
 import { createClient } from '@/lib/supabase/server'
 import BookingWizard from './BookingWizard'
 
 interface Props {
   params: Promise<{ slug: string }>
+}
+
+/**
+ * Dynamic metadata for the booking page.
+ * Gives each business a proper <title>, meta description, and Open Graph
+ * tags so links shared on WhatsApp, Instagram, etc. show the business name,
+ * tagline and cover/logo image.
+ */
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const supabase = await createClient()
+
+  const { data: business } = await supabase
+    .from('business_settings')
+    .select('name, tagline, logo_url, cover_url')
+    .eq('slug', slug)
+    .single()
+
+  if (!business) {
+    return { title: 'Book an appointment' }
+  }
+
+  const appUrl   = process.env.NEXT_PUBLIC_APP_URL ?? 'https://bookflow.app'
+  const ogImage  = business.cover_url || business.logo_url || undefined
+  const description = business.tagline
+    ? `${business.tagline} — Book your appointment online.`
+    : `Book an appointment with ${business.name} online.`
+
+  return {
+    title: `Book with ${business.name}`,
+    description,
+    openGraph: {
+      title:       `Book with ${business.name}`,
+      description,
+      url:         `${appUrl}/book/${slug}`,
+      siteName:    business.name,
+      images:      ogImage ? [{ url: ogImage }] : [],
+      type:        'website',
+    },
+    twitter: {
+      card:        ogImage ? 'summary_large_image' : 'summary',
+      title:       `Book with ${business.name}`,
+      description,
+      images:      ogImage ? [ogImage] : [],
+    },
+  }
 }
 
 /**

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,9 @@
 import { Calendar } from 'lucide-react'
 import Link from 'next/link'
-import HeroSignupForm  from './_components/landing/HeroSignupForm'
-import FeaturesSection from './_components/landing/FeaturesSection'
-import PricingSection  from './_components/landing/PricingSection'
+import HeroSignupForm       from './_components/landing/HeroSignupForm'
+import FeaturesSection      from './_components/landing/FeaturesSection'
+import PricingSection       from './_components/landing/PricingSection'
+import TestimonialsSection  from './_components/landing/TestimonialsSection'
 
 export default function LandingPage() {
   return (
@@ -100,6 +101,7 @@ export default function LandingPage() {
 
       <FeaturesSection />
       <PricingSection />
+      <TestimonialsSection />
 
       {/* Final CTA */}
       <section className="py-20 px-6 bg-indigo-600">


### PR DESCRIPTION
## What this adds

### 1. TestimonialsSection wired into the landing page

The component already existed but was never rendered. It's now placed between `<PricingSection />` and the final CTA — the natural social-proof position.

No changes to the component itself — it was already correct.

### 2. Dynamic `generateMetadata()` on `/book/[slug]`

Every booking page now has proper SEO and social sharing metadata:

- `<title>` → `Book with {businessName}`
- `<meta description>` → business tagline + call to action, or fallback
- Open Graph → title, description, URL, site name, cover/logo image
- Twitter card → `summary_large_image` if cover/logo exists, `summary` otherwise

This means when a business owner shares their booking link on WhatsApp, Instagram or Facebook, it will show their business name and cover photo in the preview instead of a blank card.

### Files changed
- `src/app/page.tsx` — import + render `<TestimonialsSection />`
- `src/app/book/[slug]/page.tsx` — `generateMetadata()` added above the existing page component

Closes part of #5