### PR TITLE
feat(mobile): responsive admin sidebar, stats grid, and overview layout

### DIFF
--- a/src/app/admin/_components/StatsBar.tsx
+++ b/src/app/admin/_components/StatsBar.tsx
@@ -6,7 +6,7 @@ type Stat = {
 
 export default function StatsBar({ stats }: { stats: Stat[] }) {
   return (
-    <div className="px-8 pb-5 grid grid-cols-4 gap-4">
+    <div className="px-4 md:px-8 pb-5 grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
       {stats.map(s => (
         <div key={s.label} className="bg-white rounded-2xl border border-gray-100 p-4 shadow-soft">
           <p className={`text-2xl font-bold mb-1 ${s.color.split(' ')[0]}`}>{s.value}</p>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,7 +2,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
-import { Calendar, BookOpen, Settings, Users, LayoutDashboard, LogOut, Loader2 } from 'lucide-react'
+import { Calendar, BookOpen, Settings, Users, LayoutDashboard, LogOut, Loader2, Menu, X } from 'lucide-react'
 import NotificationBell from './_components/NotificationBell'
 
 const NAV = [
@@ -16,8 +16,9 @@ const NAV = [
 const BARE_PATHS = ['/admin/login']
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname()
+  const pathname  = usePathname()
   const [signingOut, setSigningOut] = useState(false)
+  const [drawerOpen, setDrawerOpen] = useState(false)
 
   if (BARE_PATHS.includes(pathname)) {
     return <>{children}</>
@@ -29,58 +30,98 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     window.location.href = '/admin/login'
   }
 
+  const SidebarContent = (
+    <>
+      <div className="px-5 py-5 border-b border-gray-100 flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <div className="w-8 h-8 rounded-lg bg-indigo-600 flex items-center justify-center text-white font-bold text-sm">
+            B
+          </div>
+          <span className="font-bold text-gray-900 text-sm">BookFlow</span>
+        </div>
+        {/* Close button — mobile only */}
+        <button
+          onClick={() => setDrawerOpen(false)}
+          className="md:hidden p-1.5 rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      <nav className="flex-1 px-3 py-4 space-y-0.5">
+        {NAV.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href
+          return (
+            <Link key={href} href={href}
+              onClick={() => setDrawerOpen(false)}
+              className={`flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all ${
+                active
+                  ? 'bg-indigo-50 text-indigo-600'
+                  : 'text-gray-500 hover:bg-gray-50 hover:text-gray-900'
+              }`}>
+              <Icon className="w-4 h-4" />
+              {label}
+            </Link>
+          )
+        })}
+      </nav>
+
+      <div className="px-3 py-4 border-t border-gray-100">
+        <button
+          onClick={handleLogout}
+          disabled={signingOut}
+          className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 hover:bg-red-50 hover:text-red-600 transition-all w-full disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {signingOut
+            ? <Loader2 className="w-4 h-4 animate-spin" />
+            : <LogOut className="w-4 h-4" />}
+          {signingOut ? 'Signing out…' : 'Sign out'}
+        </button>
+      </div>
+    </>
+  )
+
   return (
     <div className="flex h-screen bg-gray-50 overflow-hidden">
-      <aside className="w-56 bg-white border-r border-gray-100 flex flex-col flex-shrink-0">
-        <div className="px-5 py-5 border-b border-gray-100">
-          <div className="flex items-center gap-2.5">
-            <div className="w-8 h-8 rounded-lg bg-indigo-600 flex items-center justify-center text-white font-bold text-sm">
-              B
-            </div>
-            <span className="font-bold text-gray-900 text-sm">BookFlow</span>
-          </div>
-        </div>
 
-        <nav className="flex-1 px-3 py-4 space-y-0.5">
-          {NAV.map(({ href, label, icon: Icon }) => {
-            const active = pathname === href
-            return (
-              <Link key={href} href={href}
-                className={`flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all ${
-                  active
-                    ? 'bg-indigo-50 text-indigo-600'
-                    : 'text-gray-500 hover:bg-gray-50 hover:text-gray-900'
-                }`}>
-                <Icon className="w-4 h-4" />
-                {label}
-              </Link>
-            )
-          })}
-        </nav>
-
-        <div className="px-3 py-4 border-t border-gray-100">
-          <button
-            onClick={handleLogout}
-            disabled={signingOut}
-            className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 hover:bg-red-50 hover:text-red-600 transition-all w-full disabled:opacity-60 disabled:cursor-not-allowed"
-          >
-            {signingOut
-              ? <Loader2 className="w-4 h-4 animate-spin" />
-              : <LogOut className="w-4 h-4" />}
-            {signingOut ? 'Signing out…' : 'Sign out'}
-          </button>
-        </div>
+      {/* ─── Desktop sidebar ───────────────────────────────────────────── */}
+      <aside className="hidden md:flex w-56 bg-white border-r border-gray-100 flex-col flex-shrink-0">
+        {SidebarContent}
       </aside>
 
-      {/* flex-col + h-full so the content area fills the screen and children can use h-full */}
-      <main className="flex-1 flex flex-col overflow-hidden">
-        <div className="flex justify-end items-center px-6 py-3 border-b border-gray-100 bg-white flex-shrink-0">
+      {/* ─── Mobile drawer overlay ────────────────────────────────────── */}
+      {drawerOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 md:hidden"
+          onClick={() => setDrawerOpen(false)}
+        />
+      )}
+      <aside className={`
+        fixed inset-y-0 left-0 z-50 w-64 bg-white flex flex-col flex-shrink-0
+        transform transition-transform duration-200 ease-in-out md:hidden
+        ${drawerOpen ? 'translate-x-0' : '-translate-x-full'}
+      `}>
+        {SidebarContent}
+      </aside>
+
+      {/* ─── Main content ───────────────────────────────────────────────── */}
+      <main className="flex-1 flex flex-col overflow-hidden min-w-0">
+        <div className="flex justify-between items-center px-4 md:px-6 py-3 border-b border-gray-100 bg-white flex-shrink-0">
+          {/* Hamburger — mobile only */}
+          <button
+            onClick={() => setDrawerOpen(true)}
+            className="md:hidden p-2 rounded-xl text-gray-500 hover:bg-gray-100 hover:text-gray-900 transition-colors"
+          >
+            <Menu className="w-5 h-5" />
+          </button>
+          <div className="hidden md:block" />{/* spacer on desktop */}
           <NotificationBell />
         </div>
         <div className="flex-1 overflow-auto">
           {children}
         </div>
       </main>
+
     </div>
   )
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -48,12 +48,9 @@ export default function AdminOverview() {
       .finally(() => setLoading(false))
   }, [])
 
-  // Business open/close hours from settings
   const settingsOpen  = parseInt(settings.open_time.split(':')[0])
   const settingsClose = parseInt(settings.close_time.split(':')[0])
 
-  // Find earliest and latest booking hours for the current view
-  // so the grid always expands to show every booking
   const visibleDates = (() => {
     if (view === 'day') return [currentDate]
     const weekStart = startOfWeek(parseISO(currentDate), { weekStartsOn: 1 })
@@ -86,10 +83,10 @@ export default function AdminOverview() {
     .reduce((sum, b) => sum + b.service_price, 0)
 
   const stats = [
-    { label: "Today's appointments", value: todayAll.length,    color: 'text-indigo-600 bg-indigo-50' },
-    { label: 'Pending confirmation',  value: pendingCount,       color: 'text-amber-600 bg-amber-50'  },
+    { label: "Today's appointments", value: todayAll.length,         color: 'text-indigo-600 bg-indigo-50' },
+    { label: 'Pending confirmation',  value: pendingCount,            color: 'text-amber-600 bg-amber-50'  },
     { label: 'Total revenue',         value: `\u20ac${totalRevenue}`, color: 'text-green-600 bg-green-50'  },
-    { label: 'Active staff',          value: staff.length,       color: 'text-purple-600 bg-purple-50' },
+    { label: 'Active staff',          value: staff.length,            color: 'text-purple-600 bg-purple-50' },
   ]
 
   if (loading) return (
@@ -98,7 +95,7 @@ export default function AdminOverview() {
         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
       </svg>
-      Loading\u2026
+      Loading…
     </div>
   )
 
@@ -106,12 +103,12 @@ export default function AdminOverview() {
     <div className="flex flex-col h-full">
 
       {/* Header */}
-      <div className="px-8 pt-8 pb-4 flex items-start justify-between gap-4">
+      <div className="px-4 md:px-8 pt-6 md:pt-8 pb-4 flex flex-col sm:flex-row sm:items-start justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Overview</h1>
           <p className="text-gray-400 mt-1 text-sm">{format(parseISO(currentDate), 'EEEE, d MMMM yyyy')}</p>
         </div>
-        <div className="flex bg-gray-100 rounded-xl p-1">
+        <div className="flex bg-gray-100 rounded-xl p-1 self-start">
           {(['day', 'week'] as const).map(v => (
             <button key={v} onClick={() => setView(v)}
               className={`px-4 py-1.5 rounded-lg text-sm font-medium transition-all ${
@@ -126,7 +123,7 @@ export default function AdminOverview() {
       <StatsBar stats={stats} />
 
       {/* Date nav */}
-      <div className="px-8 pb-4 flex items-center gap-3">
+      <div className="px-4 md:px-8 pb-4 flex items-center gap-2 md:gap-3 flex-wrap">
         <button
           onClick={() => setCurrentDate(format(addDays(parseISO(currentDate), view === 'day' ? -1 : -7), 'yyyy-MM-dd'))}
           className="w-8 h-8 flex items-center justify-center rounded-xl border-2 border-gray-100 hover:border-indigo-300 transition-colors text-gray-400 hover:text-indigo-600">&#8592;</button>
@@ -142,8 +139,8 @@ export default function AdminOverview() {
         </span>
       </div>
 
-      {/* Views */}
-      <div className="flex-1 overflow-auto px-8 pb-8">
+      {/* Views — horizontally scrollable on mobile */}
+      <div className="flex-1 overflow-auto px-4 md:px-8 pb-6 md:pb-8">
         {view === 'day' && (
           <DayView
             bookings={bookings}
@@ -156,13 +153,15 @@ export default function AdminOverview() {
           />
         )}
         {view === 'week' && (
-          <WeekView
-            weekDays={weekDays}
-            bookings={bookings}
-            staff={staff}
-            selectedBookingId={selectedBooking?.id ?? null}
-            onSelectBooking={setSelectedBooking}
-          />
+          <div className="overflow-x-auto">
+            <WeekView
+              weekDays={weekDays}
+              bookings={bookings}
+              staff={staff}
+              selectedBookingId={selectedBooking?.id ?? null}
+              onSelectBooking={setSelectedBooking}
+            />
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## What this adds

The admin panel was completely broken on mobile — fixed sidebar, 4-column stats, no hamburger. This makes it fully usable on phones.

### `layout.tsx`
- Desktop: sidebar unchanged (`hidden md:flex w-56`)
- Mobile: sidebar hidden, replaced with a slide-in drawer (`fixed`, `z-50`, `translate-x-full` → `translate-x-0`)
- Hamburger button (`Menu` icon) in top bar, visible on mobile only
- Dark backdrop behind drawer, tap anywhere to close
- `X` close button inside drawer header
- Nav links call `setDrawerOpen(false)` on tap so drawer closes on navigation

### `StatsBar.tsx`
- `grid-cols-2` on mobile → `grid-cols-4` on `md+`
- Padding and gap adjusted for smaller screens

### `page.tsx` (Overview)
- Header stacks vertically on mobile (`flex-col sm:flex-row`)
- Padding reduced on mobile (`px-4 md:px-8`, `pt-6 md:pt-8`)
- Date nav uses `flex-wrap` so it wraps on narrow screens
- Week view wrapped in `overflow-x-auto` div so calendar scrolls horizontally on mobile instead of breaking layout

Closes part of #5