### PR TITLE
feat(ui): skeleton loaders and toast notifications across admin pages

### DIFF
--- a/src/app/admin/_components/AdminSkeleton.tsx
+++ b/src/app/admin/_components/AdminSkeleton.tsx
@@ -1,0 +1,26 @@
+/**
+ * Reusable pulse skeleton for admin card lists.
+ * Pass `rows` to control how many skeleton cards to show.
+ */
+export default function AdminSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="bg-white border-2 border-gray-100 rounded-2xl p-5 animate-pulse">
+          <div className="flex items-center gap-4">
+            <div className="w-12 h-12 bg-gray-100 rounded-xl flex-shrink-0" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 bg-gray-100 rounded-lg w-1/3" />
+              <div className="h-3 bg-gray-100 rounded-lg w-1/2" />
+              <div className="h-3 bg-gray-100 rounded-lg w-1/4" />
+            </div>
+            <div className="flex gap-2">
+              <div className="h-7 w-14 bg-gray-100 rounded-lg" />
+              <div className="h-7 w-14 bg-gray-100 rounded-lg" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/admin/_components/Toast.tsx
+++ b/src/app/admin/_components/Toast.tsx
@@ -1,0 +1,70 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { CheckCircle, XCircle, Info, X } from 'lucide-react'
+
+export type ToastVariant = 'success' | 'error' | 'info'
+
+export interface ToastMessage {
+  id: string
+  message: string
+  variant: ToastVariant
+}
+
+const ICONS = {
+  success: <CheckCircle className="w-4 h-4 text-green-500 flex-shrink-0" />,
+  error:   <XCircle    className="w-4 h-4 text-red-500   flex-shrink-0" />,
+  info:    <Info       className="w-4 h-4 text-indigo-500 flex-shrink-0" />,
+}
+
+const BORDER = {
+  success: 'border-green-100',
+  error:   'border-red-100',
+  info:    'border-indigo-100',
+}
+
+function ToastItem({ toast, onDismiss }: { toast: ToastMessage; onDismiss: (id: string) => void }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // mount → slide in
+    const show   = setTimeout(() => setVisible(true),  10)
+    // auto-dismiss after 3.5 s
+    const hide   = setTimeout(() => setVisible(false), 3500)
+    const remove = setTimeout(() => onDismiss(toast.id), 3800)
+    return () => { clearTimeout(show); clearTimeout(hide); clearTimeout(remove) }
+  }, [toast.id, onDismiss])
+
+  return (
+    <div
+      className={`
+        flex items-start gap-3 bg-white border-2 ${BORDER[toast.variant]}
+        rounded-2xl px-4 py-3 shadow-lg max-w-sm w-full
+        transition-all duration-300 ease-out
+        ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}
+      `}
+    >
+      {ICONS[toast.variant]}
+      <p className="text-sm text-gray-700 flex-1 leading-snug">{toast.message}</p>
+      <button
+        onClick={() => onDismiss(toast.id)}
+        className="text-gray-300 hover:text-gray-500 transition-colors flex-shrink-0 mt-0.5"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  )
+}
+
+export default function ToastContainer({ toasts, onDismiss }: {
+  toasts: ToastMessage[]
+  onDismiss: (id: string) => void
+}) {
+  if (toasts.length === 0) return null
+  return (
+    <div className="fixed bottom-6 right-6 z-[100] flex flex-col gap-2 items-end">
+      {toasts.map(t => (
+        <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  )
+}

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -1,8 +1,11 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Search, Phone, Mail, RefreshCw, Loader2, Calendar, X, Clock } from 'lucide-react'
 import { getBookings, updateBookingStatus } from '@/lib/supabase/queries'
 import { format, parseISO } from 'date-fns'
+import AdminSkeleton  from '../_components/AdminSkeleton'
+import ToastContainer from '../_components/Toast'
+import { useToast }   from '@/hooks/useToast'
 
 type Booking = {
   id: string; ref: string; service_name: string; service_duration: number
@@ -16,23 +19,21 @@ const STATUS_STYLE: Record<string, string> = {
   confirmed: 'bg-green-100 text-green-700',
   cancelled: 'bg-red-100 text-red-600',
   completed: 'bg-gray-100 text-gray-500',
-  pending: 'bg-amber-100 text-amber-700',
+  pending:   'bg-amber-100 text-amber-700',
 }
 
 const FILTERS = ['All', 'confirmed', 'pending', 'cancelled', 'completed']
 
-// ─── Reschedule Modal ─────────────────────────────────────────────────────────
+// ─── Reschedule Modal ───────────────────────────────────────────────────
 function RescheduleModal({
-  booking,
-  onClose,
-  onSaved,
+  booking, onClose, onSaved,
 }: {
   booking: Booking
   onClose: () => void
   onSaved: () => void
 }) {
-  const [date, setDate] = useState(booking.date)
-  const [time, setTime] = useState(booking.time.slice(0, 5))
+  const [date, setDate]   = useState(booking.date)
+  const [time, setTime]   = useState(booking.time.slice(0, 5))
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
@@ -40,27 +41,20 @@ function RescheduleModal({
     if (!date || !time) { setError('Please fill in both date and time'); return }
     setSaving(true)
     setError('')
-    const res = await fetch('/api/bookings', {
+    const res  = await fetch('/api/bookings', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: booking.id, date, time }),
     })
     const json = await res.json()
-    if (!res.ok) {
-      setError(json.error ?? 'Failed to reschedule')
-      setSaving(false)
-      return
-    }
+    if (!res.ok) { setError(json.error ?? 'Failed to reschedule'); setSaving(false); return }
     onSaved()
     onClose()
   }
 
   return (
     <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center px-4" onClick={onClose}>
-      <div
-        className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6"
-        onClick={e => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6" onClick={e => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-5">
           <div>
             <h2 className="font-bold text-gray-900">Reschedule booking</h2>
@@ -70,49 +64,33 @@ function RescheduleModal({
             <X className="w-5 h-5" />
           </button>
         </div>
-
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1.5">
               <Calendar className="w-3.5 h-3.5 inline mr-1" />New date
             </label>
-            <input
-              type="date"
-              value={date}
-              min={format(new Date(), 'yyyy-MM-dd')}
+            <input type="date" value={date} min={format(new Date(), 'yyyy-MM-dd')}
               onChange={e => setDate(e.target.value)}
-              className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:border-indigo-400 transition-colors"
-            />
+              className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:border-indigo-400 transition-colors" />
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1.5">
               <Clock className="w-3.5 h-3.5 inline mr-1" />New time
             </label>
-            <input
-              type="time"
-              value={time}
-              onChange={e => setTime(e.target.value)}
-              className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:border-indigo-400 transition-colors"
-            />
+            <input type="time" value={time} onChange={e => setTime(e.target.value)}
+              className="w-full border-2 border-gray-100 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:border-indigo-400 transition-colors" />
           </div>
-
           {error && (
             <p className="text-sm text-red-500 bg-red-50 border border-red-100 rounded-xl px-4 py-2.5">⚠ {error}</p>
           )}
         </div>
-
         <div className="flex gap-3 mt-6">
-          <button
-            onClick={onClose}
-            className="flex-1 border-2 border-gray-100 text-gray-500 py-2.5 rounded-xl text-sm font-medium hover:border-gray-200 transition-colors"
-          >
+          <button onClick={onClose}
+            className="flex-1 border-2 border-gray-100 text-gray-500 py-2.5 rounded-xl text-sm font-medium hover:border-gray-200 transition-colors">
             Cancel
           </button>
-          <button
-            onClick={handleSave}
-            disabled={saving}
-            className="flex-1 bg-indigo-600 text-white py-2.5 rounded-xl text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors flex items-center justify-center gap-2"
-          >
+          <button onClick={handleSave} disabled={saving}
+            className="flex-1 bg-indigo-600 text-white py-2.5 rounded-xl text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors flex items-center justify-center gap-2">
             {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
             {saving ? 'Saving…' : 'Save changes'}
           </button>
@@ -122,28 +100,30 @@ function RescheduleModal({
   )
 }
 
-// ─── Main Page ────────────────────────────────────────────────────────────────
+// ─── Main Page ────────────────────────────────────────────────────────────
 export default function BookingsPage() {
-  const [bookings, setBookings] = useState<Booking[]>([])
-  const [loading, setLoading] = useState(true)
-  const [filter, setFilter] = useState('All')
-  const [search, setSearch] = useState('')
-  const [error, setError] = useState('')
+  const [bookings, setBookings]       = useState<Booking[]>([])
+  const [loading, setLoading]         = useState(true)
+  const [filter, setFilter]           = useState('All')
+  const [search, setSearch]           = useState('')
+  const [error, setError]             = useState('')
   const [rescheduling, setRescheduling] = useState<Booking | null>(null)
+  const { toasts, toast, dismiss }    = useToast()
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true)
     try {
       const data = await getBookings()
       setBookings(data ?? [])
+      setError('')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load bookings')
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
-  useEffect(() => { load() }, [])
+  useEffect(() => { load() }, [load])
 
   const filtered = bookings.filter(b => {
     const matchFilter = filter === 'All' || b.status === filter
@@ -156,20 +136,40 @@ export default function BookingsPage() {
     return matchFilter && matchSearch
   })
 
-  const handleStatus = async (id: string, status: 'confirmed' | 'pending' | 'cancelled' | 'completed') => {
-    await updateBookingStatus(id, status)
+  const handleStatus = async (
+    id: string,
+    status: 'confirmed' | 'pending' | 'cancelled' | 'completed',
+  ) => {
+    try {
+      await updateBookingStatus(id, status)
+      await load()
+      const labels: Record<string, string> = {
+        confirmed: 'Booking restored',
+        completed: 'Marked as complete',
+        cancelled: 'Booking cancelled',
+      }
+      toast.success(labels[status] ?? 'Status updated')
+    } catch {
+      toast.error('Failed to update booking status')
+    }
+  }
+
+  const handleRescheduleSaved = async () => {
     await load()
+    toast.success('Booking rescheduled')
   }
 
   const activeCount = bookings.filter(b => b.status === 'confirmed').length
 
   return (
-    <div className="p-8">
+    <div className="p-4 md:p-8">
+      <ToastContainer toasts={toasts} onDismiss={dismiss} />
+
       {rescheduling && (
         <RescheduleModal
           booking={rescheduling}
           onClose={() => setRescheduling(null)}
-          onSaved={load}
+          onSaved={handleRescheduleSaved}
         />
       )}
 
@@ -208,9 +208,7 @@ export default function BookingsPage() {
       </div>
 
       {loading ? (
-        <div className="flex items-center justify-center py-16 text-gray-400">
-          <Loader2 className="w-6 h-6 animate-spin mr-2" /> Loading bookings…
-        </div>
+        <AdminSkeleton rows={5} />
       ) : (
         <div className="space-y-3">
           {bookings.length === 0 && (
@@ -245,9 +243,7 @@ export default function BookingsPage() {
                     <div className="flex items-center gap-4 mt-1.5 flex-wrap">
                       <span className="text-xs text-gray-400">{format(parseISO(b.date), 'EEE d MMM')} · {b.time}</span>
                       <span className="text-xs text-gray-400">{b.service_duration} min · €{b.service_price}</span>
-                      {b.staff_name && (
-                        <span className="text-xs text-gray-400">{b.staff_name}</span>
-                      )}
+                      {b.staff_name && <span className="text-xs text-gray-400">{b.staff_name}</span>}
                     </div>
                     {b.customer_notes && (
                       <p className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded-lg mt-2 inline-block">📝 {b.customer_notes}</p>

--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -2,6 +2,9 @@
 import { useState, useEffect } from 'react'
 import { Clock, Loader2 } from 'lucide-react'
 import { getServices, upsertService, deleteService } from '@/lib/supabase/queries'
+import AdminSkeleton  from '../_components/AdminSkeleton'
+import ToastContainer from '../_components/Toast'
+import { useToast }   from '@/hooks/useToast'
 
 type Service = {
   id: string; name: string; description: string
@@ -9,25 +12,27 @@ type Service = {
 }
 
 const toForm = (s?: Service) => ({
-  name: s?.name ?? '',
+  name:        s?.name        ?? '',
   description: s?.description ?? '',
-  duration: s ? String(s.duration) : '60',
-  price: s ? String(s.price) : '0',
+  duration:    s ? String(s.duration) : '60',
+  price:       s ? String(s.price)    : '0',
 })
 
 export default function ServicesPage() {
   const [services, setServices] = useState<Service[]>([])
-  const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
+  const [loading, setLoading]   = useState(true)
+  const [saving, setSaving]     = useState(false)
   const [showModal, setShowModal] = useState(false)
-  const [editing, setEditing] = useState<Service | null>(null)
-  const [form, setForm] = useState(toForm())
-  const [error, setError] = useState('')
+  const [editing, setEditing]   = useState<Service | null>(null)
+  const [form, setForm]         = useState(toForm())
+  const [error, setError]       = useState('')
+  const { toasts, toast, dismiss } = useToast()
 
   const load = async () => {
     try {
       const data = await getServices()
       setServices(data ?? [])
+      setError('')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load services')
     } finally {
@@ -38,22 +43,24 @@ export default function ServicesPage() {
   useEffect(() => { load() }, [])
 
   const openCreate = () => { setForm(toForm()); setEditing(null); setShowModal(true) }
-  const openEdit = (s: Service) => { setForm(toForm(s)); setEditing(s); setShowModal(true) }
+  const openEdit   = (s: Service) => { setForm(toForm(s)); setEditing(s); setShowModal(true) }
 
   const handleSave = async () => {
     setSaving(true)
     try {
       await upsertService({
         ...(editing ? { id: editing.id } : {}),
-        name: form.name,
+        name:        form.name,
         description: form.description,
-        duration: Math.max(5, parseInt(form.duration) || 60),
-        price: Math.max(0, parseFloat(form.price) || 0),
+        duration:    Math.max(5, parseInt(form.duration) || 60),
+        price:       Math.max(0, parseFloat(form.price) || 0),
       })
       await load()
       setShowModal(false)
+      toast.success(editing ? 'Service updated' : 'Service created')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to save service')
+      toast.error('Failed to save service')
     } finally {
       setSaving(false)
     }
@@ -64,13 +71,17 @@ export default function ServicesPage() {
     try {
       await deleteService(id)
       await load()
+      toast.success('Service deleted')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to delete service')
+      toast.error('Failed to delete service')
     }
   }
 
   return (
-    <div className="p-8">
+    <div className="p-4 md:p-8">
+      <ToastContainer toasts={toasts} onDismiss={dismiss} />
+
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Services</h1>
@@ -83,15 +94,11 @@ export default function ServicesPage() {
       </div>
 
       {error && (
-        <div className="mb-4 bg-red-50 border border-red-100 text-red-600 text-sm rounded-xl px-4 py-3">
-          ⚠ {error}
-        </div>
+        <div className="mb-4 bg-red-50 border border-red-100 text-red-600 text-sm rounded-xl px-4 py-3">⚠ {error}</div>
       )}
 
       {loading ? (
-        <div className="flex items-center justify-center py-16 text-gray-400">
-          <Loader2 className="w-6 h-6 animate-spin mr-2" /> Loading services…
-        </div>
+        <AdminSkeleton rows={3} />
       ) : (
         <div className="grid gap-4">
           {services.map((s, i) => (
@@ -115,6 +122,13 @@ export default function ServicesPage() {
               </div>
             </div>
           ))}
+          {services.length === 0 && (
+            <div className="text-center py-16 text-gray-400">
+              <p className="text-4xl mb-3">✨</p>
+              <p className="font-medium">No services yet</p>
+              <p className="text-sm mt-1">Add your first service to start taking bookings.</p>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/app/admin/staff/page.tsx
+++ b/src/app/admin/staff/page.tsx
@@ -2,11 +2,13 @@
 import { useState, useEffect } from 'react'
 import { Clock, Plus, X, Search, Loader2 } from 'lucide-react'
 import {
-  getStaff, upsertStaffMember, deleteStaffMember,
-  getServices,
+  getStaff, upsertStaffMember, deleteStaffMember, getServices,
 } from '@/lib/supabase/queries'
+import AdminSkeleton  from '../_components/AdminSkeleton'
+import ToastContainer from '../_components/Toast'
+import { useToast }   from '@/hooks/useToast'
 
-const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const DAYS   = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const COLORS = ['#6366f1', '#ec4899', '#f59e0b', '#10b981', '#3b82f6', '#8b5cf6', '#ef4444']
 
 type DBService = { id: string; name: string; duration: number; price: number }
@@ -26,21 +28,23 @@ const emptyForm = {
 }
 
 export default function StaffPage() {
-  const [members, setMembers] = useState<DBStaff[]>([])
-  const [services, setServices] = useState<DBService[]>([])
-  const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
+  const [members, setMembers]     = useState<DBStaff[]>([])
+  const [services, setServices]   = useState<DBService[]>([])
+  const [loading, setLoading]     = useState(true)
+  const [saving, setSaving]       = useState(false)
   const [showModal, setShowModal] = useState(false)
-  const [editing, setEditing] = useState<DBStaff | null>(null)
-  const [form, setForm] = useState({ ...emptyForm })
+  const [editing, setEditing]     = useState<DBStaff | null>(null)
+  const [form, setForm]           = useState({ ...emptyForm })
   const [skillSearch, setSkillSearch] = useState('')
-  const [error, setError] = useState('')
+  const [error, setError]         = useState('')
+  const { toasts, toast, dismiss } = useToast()
 
   const loadAll = async () => {
     try {
       const [staffData, svcData] = await Promise.all([getStaff(), getServices()])
       setMembers((staffData ?? []) as DBStaff[])
-      setServices((svcData ?? []) as DBService[])
+      setServices((svcData  ?? []) as DBService[])
+      setError('')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load data')
     } finally {
@@ -50,62 +54,40 @@ export default function StaffPage() {
 
   useEffect(() => { loadAll() }, [])
 
-  const openCreate = () => {
-    setForm({ ...emptyForm })
-    setEditing(null)
-    setSkillSearch('')
-    setShowModal(true)
-  }
-
-  const openEdit = (m: DBStaff) => {
-    setForm({
-      name: m.name, role: m.role, bio: m.bio,
-      service_ids: [...m.service_ids],
-      work_days: [...m.work_days],
-      work_start: m.work_start, work_end: m.work_end,
-      active: m.active, color: m.color,
-    })
-    setEditing(m)
-    setSkillSearch('')
-    setShowModal(true)
+  const openCreate = () => { setForm({ ...emptyForm }); setEditing(null); setSkillSearch(''); setShowModal(true) }
+  const openEdit   = (m: DBStaff) => {
+    setForm({ name: m.name, role: m.role, bio: m.bio, service_ids: [...m.service_ids],
+      work_days: [...m.work_days], work_start: m.work_start, work_end: m.work_end,
+      active: m.active, color: m.color })
+    setEditing(m); setSkillSearch(''); setShowModal(true)
   }
 
   const toggleService = (id: string) =>
-    setForm(p => ({
-      ...p,
-      service_ids: p.service_ids.includes(id)
-        ? p.service_ids.filter(s => s !== id)
-        : [...p.service_ids, id],
-    }))
+    setForm(p => ({ ...p, service_ids: p.service_ids.includes(id)
+      ? p.service_ids.filter(s => s !== id)
+      : [...p.service_ids, id] }))
 
   const toggleDay = (d: number) =>
-    setForm(p => ({
-      ...p,
-      work_days: p.work_days.includes(d)
-        ? p.work_days.filter(x => x !== d)
-        : [...p.work_days, d].sort(),
-    }))
+    setForm(p => ({ ...p, work_days: p.work_days.includes(d)
+      ? p.work_days.filter(x => x !== d)
+      : [...p.work_days, d].sort() }))
 
   const handleSave = async () => {
-    setSaving(true)
-    setError('')
+    setSaving(true); setError('')
     try {
       await upsertStaffMember({
         ...(editing ? { id: editing.id } : {}),
-        name: form.name,
-        role: form.role,
-        bio: form.bio,
-        service_ids: form.service_ids,
-        work_days: form.work_days,
-        work_start: form.work_start,
-        work_end: form.work_end,
-        active: form.active,
-        color: form.color,
+        name: form.name, role: form.role, bio: form.bio,
+        service_ids: form.service_ids, work_days: form.work_days,
+        work_start: form.work_start, work_end: form.work_end,
+        active: form.active, color: form.color,
       })
       await loadAll()
       setShowModal(false)
+      toast.success(editing ? 'Staff member updated' : 'Staff member added')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to save staff member')
+      toast.error('Failed to save staff member')
     } finally {
       setSaving(false)
     }
@@ -116,8 +98,10 @@ export default function StaffPage() {
     try {
       await deleteStaffMember(id)
       await loadAll()
+      toast.success('Staff member removed')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to delete staff member')
+      toast.error('Failed to remove staff member')
     }
   }
 
@@ -125,8 +109,10 @@ export default function StaffPage() {
     try {
       await upsertStaffMember({ ...m, active: !m.active })
       await loadAll()
+      toast.success(m.active ? `${m.name} set to inactive` : `${m.name} set to active`)
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to update staff member')
+      toast.error('Failed to update staff member')
     }
   }
 
@@ -135,7 +121,9 @@ export default function StaffPage() {
   )
 
   return (
-    <div className="p-8">
+    <div className="p-4 md:p-8">
+      <ToastContainer toasts={toasts} onDismiss={dismiss} />
+
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Staff</h1>
@@ -154,9 +142,7 @@ export default function StaffPage() {
       )}
 
       {loading ? (
-        <div className="flex items-center justify-center py-16 text-gray-400">
-          <Loader2 className="w-6 h-6 animate-spin mr-2" /> Loading staff…
-        </div>
+        <AdminSkeleton rows={3} />
       ) : (
         <div className="grid gap-4">
           {members.map(m => {
@@ -230,7 +216,6 @@ export default function StaffPage() {
         </div>
       )}
 
-      {/* Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black/40 z-50 flex items-start justify-center p-4 overflow-y-auto">
           <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg p-6 my-8">
@@ -244,7 +229,6 @@ export default function StaffPage() {
             </div>
 
             <div className="space-y-5">
-              {/* Colour picker */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">Avatar colour</label>
                 <div className="flex gap-2 items-center">
@@ -286,7 +270,6 @@ export default function StaffPage() {
                   rows={2} placeholder="Short description shown to customers" />
               </div>
 
-              {/* Skill picker — now from Supabase */}
               <div>
                 <div className="flex items-center justify-between mb-2">
                   <label className="text-sm font-medium text-gray-700">
@@ -336,7 +319,6 @@ export default function StaffPage() {
                 </p>
               </div>
 
-              {/* Working days */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">Working days</label>
                 <div className="flex gap-2">

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,26 @@
+'use client'
+import { useState, useCallback } from 'react'
+import type { ToastMessage, ToastVariant } from '@/app/admin/_components/Toast'
+
+export function useToast() {
+  const [toasts, setToasts] = useState<ToastMessage[]>([])
+
+  const dismiss = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  const add = useCallback((message: string, variant: ToastVariant = 'info') => {
+    const id = Math.random().toString(36).slice(2)
+    setToasts(prev => [...prev, { id, message, variant }])
+  }, [])
+
+  const toast = Object.assign(
+    (message: string) => add(message, 'info'),
+    {
+      success: (message: string) => add(message, 'success'),
+      error:   (message: string) => add(message, 'error'),
+    }
+  )
+
+  return { toasts, toast, dismiss }
+}


### PR DESCRIPTION
## What this adds

No external dependencies — everything is built from scratch with Tailwind.

### New shared components

**`Toast.tsx`** + **`useToast.ts`**
- Fixed bottom-right toast stack, `z-[100]` so it's above everything
- Three variants: `success` (green), `error` (red), `info` (indigo)
- Slide-in animation on mount (`opacity-0 translate-y-2` → `opacity-100 translate-y-0`)
- Auto-dismiss after 3.5s, smooth fade-out before removal
- Manual dismiss via `×` button
- `useToast` hook exposes `toast('msg')`, `toast.success('msg')`, `toast.error('msg')`

**`AdminSkeleton.tsx`**
- Animated `animate-pulse` card skeleton matching the shape of the real cards
- Accepts `rows` prop — each page passes the right number

### Pages updated

| Page | Skeleton | Toasts |
|---|---|---|
| Bookings | ✅ 5-row skeleton replaces spinner | ✅ Mark complete, cancel, restore, reschedule |
| Services | ✅ 3-row skeleton replaces spinner | ✅ Create, update, delete |
| Staff | ✅ 3-row skeleton replaces spinner | ✅ Save, delete, toggle active/inactive |

Closes part of #5